### PR TITLE
Configure setuptools packaging for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,14 @@ dev = [
 
 [tool.uv]
 default-groups = ["dev", "docs", "test"]
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["polars_eval_metrics*"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -565,7 +565,7 @@ wheels = [
 [[package]]
 name = "demo-eval-metric"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "numpy" },
     { name = "polars" },


### PR DESCRIPTION
## Summary
- configure setuptools build backend and package discovery for the src layout
- update uv.lock to record the project as an editable dependency

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1d7e8053883318385516e3a2c494f